### PR TITLE
get correct value for atcud

### DIFF
--- a/src/Rebelo/ATWs/StockMovement/Ws.php
+++ b/src/Rebelo/ATWs/StockMovement/Ws.php
@@ -102,7 +102,7 @@ class Ws extends AATWs implements IWs
 
         $xml->writeElement(
             "ATCUD",
-            $doc->getTaxRegistrationNumber()
+            $doc->getAtcud()
         );
 
         if ($doc->getATDocCodeID() !== null) {


### PR DESCRIPTION
buildBodyStockMovement uses the wrong method to get atcud value